### PR TITLE
Filemanager fix related to session locked issue

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/connectors/php/filemanager.class.php
+++ b/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/connectors/php/filemanager.class.php
@@ -79,16 +79,18 @@ class Filemanager
         // else it takes $_SERVER['DOCUMENT_ROOT'] default value
         if ($this->config['options']['fileRoot'] !== false) {
             if ($this->config['options']['serverRoot'] === true) {
-                $this->doc_root      = $_SERVER['DOCUMENT_ROOT'];
+                // modif DDC pour coller a la config des server wmk
+                $this->doc_root      = substr(__DIR__, 0, strpos(__DIR__, '/app/'));
                 $this->separator     = basename($this->config['options']['fileRoot']);
-                $this->path_to_files = $_SERVER['DOCUMENT_ROOT'].'/'.$this->config['options']['fileRoot'];
+                $this->path_to_files = substr(__DIR__, 0, strpos(__DIR__, '/app/')).'/'.$this->config['options']['fileRoot'];
             } else {
                 $this->doc_root      = $this->config['options']['fileRoot'];
                 $this->separator     = basename($this->config['options']['fileRoot']);
                 $this->path_to_files = $this->config['options']['fileRoot'];
             }
         } else {
-            $this->doc_root      = $_SERVER['DOCUMENT_ROOT'];
+            // modif DDC pour coller a la config des server wmk
+            $this->doc_root      = substr(__DIR__, 0, strpos(__DIR__, '/app/'));
             $this->path_to_files = $this->root.$this->separator.'/';
         }
 
@@ -112,9 +114,8 @@ class Filemanager
     // allow Filemanager to be used with dynamic folders
     public function setFileRoot($path, $documentRoot = null)
     {
-        if ($documentRoot == null) {
-            $documentRoot = $_SERVER['DOCUMENT_ROOT'];
-        }
+        // modif pour coller au server wmk
+        $documentRoot = substr(__DIR__, 0, strpos(__DIR__, '/app/'));
 
         // Paths are bit complex to handle - kind of nightmare actually ....
         // 3 parts are availables
@@ -971,7 +972,7 @@ class Filemanager
             header('Content-Transfer-Encoding: Binary');
             header('Content-length: '.filesize($returned_path));
             header('Content-Disposition: inline; filename="'.basename($returned_path).'"');
-
+            usleep(rand(500000, 1000000));
             readfile($returned_path);
 
             exit();

--- a/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/connectors/php/user.config.php
+++ b/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/connectors/php/user.config.php
@@ -44,8 +44,13 @@ try {
     $container->get('event_dispatcher')->dispatch(KernelEvents::REQUEST, $event);
 
     $session       = $container->get('session');
+    $userDir       = $session->get('mautic.imagepath', false);
+    $baseDir       = $session->get('mautic.basepath', false);
+    $docRoot       = $session->get('mautic.docroot', false);
+
     $securityToken = $container->get('security.token_storage');
     $token         = $securityToken->getToken();
+    session_abort();
     $authenticated = ($token instanceof TokenInterface) ? count($token->getRoles()) : false;
 } catch (\Exception $exception) {
     error_log($exception);
@@ -81,10 +86,6 @@ function auth()
 $fm = new Filemanager();
 
 if ($authenticated) {
-    $userDir = $session->get('mautic.imagepath', false);
-    $baseDir = $session->get('mautic.basepath', false);
-    $docRoot = $session->get('mautic.docroot', false);
-
     if (substr($userDir, -1) !== '/') {
         $userDir .= '/';
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fixed filemanager for Mautic 2 for error log:

`[2020-04-30 06:49:11] mautic.WARNING: PHP Warning - SessionHandler::read(): Unable to clear session lock record - in file /home/atmt_support/support.automation.webmecanik.com/2-15-4-atmt/vendor/symfony/http-foundation/Session/Storage/Proxy/SessionHandlerProxy.php - at line 62 {"sessionId":"2a94916970f1541561d5c3eaf3057a5b"} []`

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
